### PR TITLE
Tolerate 128bit ids by throwing out high bits

### DIFF
--- a/request.go
+++ b/request.go
@@ -43,7 +43,13 @@ type HeaderSetter interface {
 // RequestFromHeader will create a Request object given an http.Header or
 // anything that matches the HeaderGetter interface.
 func RequestFromHeader(header HeaderGetter) (rv Request) {
-	trace_id, err := fromHeader(header.Get("X-B3-TraceId"))
+	// Tolerate 128bit traceIDs.
+	// SEE: https://github.com/openzipkin/b3-propagation/issues/6
+	b3TraceID := header.Get("X-B3-TraceId")
+	if len(b3TraceID) > 16 {
+		b3TraceID = b3TraceID[len(b3TraceID)-16:]
+	}
+	trace_id, err := fromHeader(b3TraceID)
 	if err == nil {
 		rv.TraceId = &trace_id
 	}


### PR DESCRIPTION
This bridges support for 128bit trace ids by not failing on their
receipt. Basically, this throws out any hex characters to the left
of the 16 needed for the 64bit trace id.

see: https://github.com/openzipkin/b3-propagation/issues/6
